### PR TITLE
use 3.12 to build the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: ["3.10", "3.11", "3.12"]
+    python: "3.12"
   apt_packages:
     - doxygen
   jobs:


### PR DESCRIPTION
build error for the python version fix