### PR TITLE
[docs] Simplifying build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ pytest -v tests/fast_pauli
 
 #### Configurable Build (Developers)
 ```bash
+python -m pip install --upgrade pip
 python -m pip install scikit-build-core
 python -m pip install --no-build-isolation -ve ".[dev]" -C cmake.args="-DCMAKE_CXX_COMPILER=<compiler> + <other cmake flags>"
 pytest -v tests/fast_pauli # + other pytest flags

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ pytest -v tests/fast_pauli
 
 #### Configurable Build (Developers)
 ```bash
+python -m pip install scikit-build-core
 python -m pip install --no-build-isolation -ve ".[dev]" -C cmake.args="-DCMAKE_CXX_COMPILER=<compiler> + <other cmake flags>"
 pytest -v tests/fast_pauli # + other pytest flags
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <tr>
     <td>Package</td>
     <td>
-    <img alt="PyPI - Version" src="https://img.shields.io/pypi/v/fast_pauli?color=4c1">
+    <a href="https://pypi.org/project/fast-pauli/"><img alt="PyPI - Version" src="https://img.shields.io/pypi/v/fast_pauli?color=4c1"></a>
     </td>
   </tr>
   <tr>

--- a/README.md
+++ b/README.md
@@ -73,11 +73,7 @@ pytest -v tests/fast_pauli
 
 #### Configurable Build (Developers)
 ```bash
-cmake -B build -G Ninja # + other cmake flags
-cmake --build build --target install --parallel
-ctest --test-dir build
-
-python -m pip install --no-build-isolation -ve.
+python -m pip install --no-build-isolation -ve ".[dev]" -C cmake.args="-DCMAKE_CXX_COMPILER=<compiler> + <other cmake flags>"
 pytest -v tests/fast_pauli # + other pytest flags
 ```
 Compiled `_fast_pauli` python module gets installed into `fast_pauli` directory.

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -66,10 +66,10 @@ Again, we saw significant performance improvements for the same reasons stated a
 Note that :code:`fast-pauli` performs better relative to :code:`qiskit` when the Pauli Operator is more sparse, i.e. when there are fewer Pauli Strings in the operator.
 
 
-Expectation Value of a Pauli Operator
+Expectation Values of a Pauli Operator
 -------------------------------------------------------------------
 
-Finally, we benchmarked the expectation value of a Pauli Operator applied to a **batch** of states:
+Finally, we benchmarked the expectation values of a Pauli Operator applied to a **batch** of states:
 
 .. math::
     :label: pauli_op_expectation_value

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,9 +22,7 @@ inspired by `PauliComposer <https://arxiv.org/abs/2301.00560>`_ paper.
 :code:`fast-pauli` aims to provide a fast and efficient alternative to existing libraries for working with Pauli matrices and strings,
 with a focus on performance and usability.
 For example, :code:`fast-pauli` provides optimized functions to apply Pauli strings and operators to a batch of states rather than just a single state vector.
-See our :doc:`benchmarks` for more details about how :code:`fast-pauli` can speed up certain functions compared to Qiskit.
-
-Our :doc:`getting_started` guide offers an introduction to some of the core functionality in :code:`fast-pauli`.
+See our :doc:`getting_started` guide for an introduction to some of the core functionality in :code:`fast-pauli` and our :doc:`benchmarks` for more details about how :code:`fast-pauli` can speed up certain functions compared to Qiskit.
 
 Installation
 ============
@@ -53,14 +51,7 @@ Build from Source (Custom Config)
 
    git clone git@github.com:qognitive/fast-pauli.git
    cd fast-pauli
-
-   # Configure/Compile the project
-   cmake -B build -G Ninja # <...custom cmake flags...>
-   cmake --build build --target install --parallel
-   ctest --test-dir build
-
-   # Install the python package
-   python -m pip install -e ".[dev]" --no-build-isolation
+   python -m pip install --no-build-isolation -ve ".[dev]" -C cmake.args="-DCMAKE_CXX_COMPILER=<compiler> + <other cmake flags>"
 
 Verify / Test Build
 -------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,7 @@ Build from Source (Custom Config)
 
    git clone git@github.com:qognitive/fast-pauli.git
    cd fast-pauli
+   python -m pip install scikit-build-core
    python -m pip install --no-build-isolation -ve ".[dev]" -C cmake.args="-DCMAKE_CXX_COMPILER=<compiler> + <other cmake flags>"
 
 Verify / Test Build

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,7 @@ Build from Source (Custom Config)
 
    git clone git@github.com:qognitive/fast-pauli.git
    cd fast-pauli
+   python -m pip install --upgrade pip
    python -m pip install scikit-build-core
    python -m pip install --no-build-isolation -ve ".[dev]" -C cmake.args="-DCMAKE_CXX_COMPILER=<compiler> + <other cmake flags>"
 


### PR DESCRIPTION
# Summary

This PR removes the mention of cmake from the build instructions and drives everything through pip. See [nanobind docs here](https://nanobind.readthedocs.io/en/latest/packaging.html#step-3-set-up-a-cmake-build-system)