### PR TITLE
[DOC] Adding MacOS install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
       <a href='https://qognitive-fast-pauli.readthedocs-hosted.com/en/latest/?badge=latest'>
     <img src='https://readthedocs.com/projects/qognitive-fast-pauli/badge/?version=latest' alt='Documentation Status' />
 </a>
-    <a href="https://github.com/qognitive/fast-pauli/tree/develop?tab=readme-ov-file#installation"><img src="https://img.shields.io/badge/Docs-Installation-blue" alt="Installation"></a>
+    <a href="https://qognitive-fast-pauli.readthedocs-hosted.com/en/latest/#installation"><img src="https://img.shields.io/badge/Docs-Installation-blue" alt="Installation"></a>
      </td>
   </tr>
   <tr>
@@ -64,19 +64,37 @@ There are two strategies for building `fast_pauli` from source. One is a quick a
 - [Ninja](https://pypi.org/project/ninja/) >= 1.11
 - C++ compiler with OpenMP and C++20 support ([LLVM](https://apt.llvm.org/) recommended)
 - [Python](https://www.python.org/downloads/) >= 3.10
+- [scikit-build-core](https://pypi.org/project/scikit-build-core/) (ONLY for building from source with custom configuration)
 
-#### Quick Start (Users)
+#### Build from Source (Linux)
 ```bash
+# Build
 python -m pip install -e ".[dev]"
+# Test
 pytest -v tests/fast_pauli
 ```
 
-#### Configurable Build (Developers)
+#### Build from Source (MacOS)
+
 ```bash
+# Setup
 python -m pip install --upgrade pip
 python -m pip install scikit-build-core
-python -m pip install --no-build-isolation -ve ".[dev]" -C cmake.args="-DCMAKE_CXX_COMPILER=<compiler> + <other cmake flags>"
+brew install llvm
+# Build
+pip install -e . -C cmake.args="-DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++;-DCMAKE_CXX_FLAGS='-stdlib=libc++ -fexperimental-library'"
+# Test
 pytest -v tests/fast_pauli # + other pytest flags
 ```
-Compiled `_fast_pauli` python module gets installed into `fast_pauli` directory.
+
+#### Build from Source (Custom Configuration)
+```bash
+# Setup
+python -m pip install --upgrade pip
+python -m pip install scikit-build-core
+# Build
+python -m pip install --no-build-isolation -ve ".[dev]" -C cmake.args="-DCMAKE_CXX_COMPILER=<compiler> + <other cmake flags>"
+# Test
+pytest -v tests/fast_pauli # + other pytest flags
+```
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,14 @@ Installation
 ============
 In order to get started, we'll need to install the package and its dependencies.
 
+Requirements
+------------
+- `CMake <https://pypi.org/project/cmake/>`_ >= 3.25
+- `Ninja <https://pypi.org/project/ninja/>`_ >= 1.11
+- C++ compiler with OpenMP and C++20 support (`LLVM <https://apt.llvm.org/>`_ recommended)
+- `Python <https://www.python.org/downloads/>`_ >= 3.10
+- `scikit-build-core <https://pypi.org/project/scikit-build-core/>`_ (ONLY for building from source with custom configuration)
+
 In the following subsections, we describe several options for installing ``fast_pauli``.
 
 Install the Latest Release
@@ -36,7 +44,7 @@ Install the Latest Release
 
    pip install fast_pauli
 
-Build from Source (Default Config)
+Build from Source (Linux)
 -----------------------------------------
 .. code-block:: bash
 
@@ -44,6 +52,16 @@ Build from Source (Default Config)
    cd fast_pauli
    python -m pip install -e ".[dev]"
 
+Build from Source (MacOS)
+-----------------------------------------
+.. code-block:: bash
+
+   git clone git@github.com:qognitive/fast-pauli.git
+   cd fast_pauli
+   python -m pip install --upgrade pip
+   python -m pip install scikit-build-core
+   brew install llvm
+   pip install -e . -C cmake.args="-DCMAKE_CXX_COMPILER=$(brew --prefix llvm)/bin/clang++;-DCMAKE_CXX_FLAGS='-stdlib=libc++ -fexperimental-library'"
 
 Build from Source (Custom Config)
 ---------------------------------


### PR DESCRIPTION
# Summary

This PR adds documentation specifically for building from source on MacOS that we were lacking (see #74). It also adds a requirements section to the install page on RTD.