### PR TITLE
Deep copy for all fast-pauli objects; new properties for SPO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
                                                "MinSizeRel" "RelWithDebInfo")
 endif()
+message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 # Set up OpenMP
 find_package(OpenMP REQUIRED)

--- a/fast_pauli/cpp/include/__nb_helpers.hpp
+++ b/fast_pauli/cpp/include/__nb_helpers.hpp
@@ -193,6 +193,23 @@ nb::ndarray<nb::numpy, T> owning_ndarray_like_mdspan(std::mdspan<T, std::dextent
     return owning_ndarray_from_shape<T, ndim>(shape);
 }
 
+/**
+ * @brief Creates a new nb::ndarray that owns the data and has the same content and shape
+ * as an mdspan.
+ *
+ * @tparam T Type of the underlying data in ndarray/mdspan
+ * @tparam ndim Rank of the array
+ * @param a The mdspan
+ * @return nb::ndarray<nb::numpy, T>
+ */
+template <typename T, size_t ndim>
+nb::ndarray<nb::numpy, T> owning_ndarray_from_mdspan(std::mdspan<T, std::dextents<size_t, ndim>> a)
+{
+    auto ndarray = owning_ndarray_like_mdspan<T, ndim>(a);
+    std::memcpy(ndarray.data(), a.data_handle(), a.size() * sizeof(T));
+    return ndarray;
+}
+
 } // namespace fast_pauli::__detail
 
 #endif // __NB_HELPERS_HPP

--- a/fast_pauli/cpp/include/__summed_pauli_op.hpp
+++ b/fast_pauli/cpp/include/__summed_pauli_op.hpp
@@ -614,6 +614,27 @@ template <std::floating_point T> struct SummedPauliOp
     }
 
     /**
+     * @brief Return the components of the SummedPauliOp as a vector of PauliOps
+     *
+     * @return std::vector<PauliOp<T>>
+     */
+    std::vector<PauliOp<T>> split() const
+    {
+        std::vector<std::complex<T>> op_coeffs(n_pauli_strings());
+        std::vector<PauliOp<T>> ops;
+        ops.reserve(n_operators());
+
+        for (size_t k = 0; k < n_operators(); k++)
+        {
+            for (size_t i = 0; i < n_pauli_strings(); i++)
+                op_coeffs[i] = coeffs(i, k);
+            ops.push_back(PauliOp<T>(op_coeffs, pauli_strings));
+        }
+
+        return ops;
+    }
+
+    /**
      * @brief Get the dense representation of the SummedPauliOp as a 3D tensor
      *
      * @param A_k_out The output tensor to fill with the dense representation

--- a/fast_pauli/cpp/src/fast_pauli.cpp
+++ b/fast_pauli/cpp/src/fast_pauli.cpp
@@ -1029,7 +1029,7 @@ np.ndarray
 )%")
         .def_prop_ro(
             "pauli_strings", [](fp::SummedPauliOp<float_type> const &self) { return self.pauli_strings; },
-            "List[PauliString]: Ordered list of PauliString objects in SummedPauliOp")
+            "List[PauliString]: The list of PauliString objects corresponding to coefficients in SummedPauliOp")
         .def_prop_ro(
             "pauli_strings_as_str",
             [](fp::SummedPauliOp<float_type> const &self) {
@@ -1038,7 +1038,7 @@ np.ndarray
                                [](fp::PauliString const &ps) { return fmt::format("{}", ps); });
                 return strings;
             },
-            "List[str]: Ordered list of Pauli Strings representations from SummedPauliOp")
+            "List[str]: The list of Pauli Strings representations corresponding to coefficients from SummedPauliOp")
 
         .def(
             "apply",

--- a/fast_pauli/cpp/src/fast_pauli.cpp
+++ b/fast_pauli/cpp/src/fast_pauli.cpp
@@ -87,6 +87,15 @@ np.ndarray
     2D numpy array of complex numbers
 )%")
         .def(
+            "clone", [](fp::Pauli const &self) { return fp::Pauli(self); },
+            R"%(Returns a copy of the Pauli object.
+
+Returns
+-------
+Pauli
+    A copy of the Pauli object
+)%")
+        .def(
             "__str__", [](fp::Pauli const &self) { return fmt::format("{}", self); },
             R"%(Returns a string representation of Pauli matrix.
 
@@ -314,7 +323,16 @@ Returns
 -------
 np.ndarray
     2D numpy array of complex numbers
-    )%");
+    )%")
+        .def(
+            "clone", [](fp::PauliString const &self) { return fp::PauliString(self); },
+            R"%(Returns a copy of the PauliString object.
+
+Returns
+-------
+PauliString
+    A copy of the PauliString object
+)%");
 
     //
     //
@@ -735,7 +753,6 @@ dedupe : bool
         .def_prop_ro("n_qubits", &fp::PauliOp<float_type>::n_qubits, "int: The number of qubits in PauliOp")
         .def_prop_ro("n_pauli_strings", &fp::PauliOp<float_type>::n_pauli_strings,
                      "int: The number of PauliString terms in PauliOp")
-        // TODO these may dangerous, keep an eye on them if users start modifying internals
         .def_prop_ro(
             "coeffs", [](fp::PauliOp<float_type> const &self) { return self.coeffs; },
             "List[complex]: Ordered list of coefficients corresponding to Pauli strings")
@@ -889,7 +906,18 @@ Returns
 -------
 np.ndarray
     2D numpy array of complex numbers with a shape of :math:`2^n \times 2^n, n` - number of qubits
-    )%");
+    )%")
+        .def(
+            "clone", [](fp::PauliOp<float_type> const &self) { return fp::PauliOp<float_type>(self); },
+            R"%(Returns a copy of the PauliOp object.
+
+Returns
+-------
+PauliOp
+    A copy of the PauliOp object
+)%")
+
+        ;
 
     //
     //
@@ -1120,7 +1148,18 @@ Returns
 np.ndarray
     3D numpy array of complex numbers with a shape of (n_operators, 2^n_qubits, 2^n_qubits)
 )%")
-        //
+        .def(
+            "clone",
+            [](fp::SummedPauliOp<float_type> const &self) {
+                return fp::SummedPauliOp<float_type>(self.pauli_strings, self.coeffs_raw);
+            },
+            R"%(Returns a copy of the SummedPauliOp object.
+
+Returns
+-------
+SummedPauliOp
+    A copy of the SummedPauliOp object
+)%")
         .def("square", &fp::SummedPauliOp<float_type>::square, R"%(Square the SummedPauliOp.
 
 Returns

--- a/fast_pauli/cpp/src/fast_pauli.cpp
+++ b/fast_pauli/cpp/src/fast_pauli.cpp
@@ -1075,12 +1075,12 @@ np.ndarray
 Parameters
 ----------
 states : np.ndarray
-    The original state(s) represented as 2D numpy array (n_operators, n_states) for batched calculation.
+    The original state(s) represented as 2D numpy array (n_dims, n_states) for batched calculation.
 
 Returns
 -------
 np.ndarray
-    New state(s) in a form of 2D numpy array (n_operators, n_states) according to the shape of input states
+    New state(s) in a form of 2D numpy array (n_dims, n_states) according to the shape of input states
 )%")
 
         .def(
@@ -1121,14 +1121,14 @@ np.ndarray
 Parameters
 ----------
 states : np.ndarray
-    The original state(s) represented as 2D numpy array (n_operators, n_states) for batched calculation.
+    The original state(s) represented as 2D numpy array (n_dims, n_states) for batched calculation.
 data : np.ndarray
     The data to weight the operators corresponding to the states (n_operators, n_states)
 
 Returns
 -------
 np.ndarray
-    New state(s) in a form of 2D numpy array (n_operators, n_states) according to the shape of input states
+    New state(s) in a form of 2D numpy array (n_dims, n_states) according to the shape of input states
 )%")
         .def(
             "expectation_value",

--- a/fast_pauli/cpp/src/fast_pauli.cpp
+++ b/fast_pauli/cpp/src/fast_pauli.cpp
@@ -1027,6 +1027,19 @@ Returns
 np.ndarray
     Array of coefficients corresponding with shape (n_operators, n_pauli_strings)
 )%")
+        .def_prop_ro(
+            "pauli_strings", [](fp::SummedPauliOp<float_type> const &self) { return self.pauli_strings; },
+            "List[PauliString]: Ordered list of PauliString objects in SummedPauliOp")
+        .def_prop_ro(
+            "pauli_strings_as_str",
+            [](fp::SummedPauliOp<float_type> const &self) {
+                std::vector<std::string> strings(self.n_pauli_strings());
+                std::transform(self.pauli_strings.begin(), self.pauli_strings.end(), strings.begin(),
+                               [](fp::PauliString const &ps) { return fmt::format("{}", ps); });
+                return strings;
+            },
+            "List[str]: Ordered list of Pauli Strings representations from SummedPauliOp")
+
         .def(
             "apply",
             [](fp::SummedPauliOp<float_type> const &self, nb::ndarray<cfloat_t> states) {

--- a/fast_pauli/cpp/src/fast_pauli.cpp
+++ b/fast_pauli/cpp/src/fast_pauli.cpp
@@ -755,10 +755,10 @@ dedupe : bool
                      "int: The number of PauliString terms in PauliOp")
         .def_prop_ro(
             "coeffs", [](fp::PauliOp<float_type> const &self) { return self.coeffs; },
-            "List[complex]: Ordered list of coefficients corresponding to Pauli strings")
+            "List[complex]: The list of coefficients corresponding to Pauli strings")
         .def_prop_ro(
             "pauli_strings", [](fp::PauliOp<float_type> const &self) { return self.pauli_strings; },
-            "List[PauliString]: Ordered list of PauliString objects in PauliOp")
+            "List[PauliString]: The list of PauliString objects corresponding to coefficients in PauliOp")
         .def_prop_ro(
             "pauli_strings_as_str",
             [](fp::PauliOp<float_type> const &self) {
@@ -768,7 +768,7 @@ dedupe : bool
                                [](fp::PauliString const &ps) { return fmt::format("{}", ps); });
                 return strings;
             },
-            "List[str]: Ordered list of Pauli Strings representations from PauliOp")
+            "List[str]: The list of PauliString representations corresponding to coefficients in PauliOp")
 
         // Methods
         .def(

--- a/tests/fast_pauli/test_pauli.py
+++ b/tests/fast_pauli/test_pauli.py
@@ -74,5 +74,19 @@ def test_exceptions(pauli: type[fp.Pauli]) -> None:
         pauli(5)
 
 
+@pytest.mark.parametrize("pauli,", [(fp.Pauli)], ids=resolve_parameter_repr)
+def test_clone(paulis: dict, pauli: type[fp.Pauli]) -> None:
+    """Test clone method."""
+    for i in paulis:
+        p1 = pauli(i)
+        p2 = p1.clone()
+
+        np.testing.assert_array_equal(
+            p1.to_tensor(),
+            p2.to_tensor(),
+        )
+        assert id(p1) != id(p2)
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/fast_pauli/test_pauli_op.py
+++ b/tests/fast_pauli/test_pauli_op.py
@@ -945,5 +945,37 @@ def test_exceptions(
         pauli_op([1, 1], ["XYZ", "ZYX"]).expectation_value(np.eye(16))
 
 
+@pytest.mark.parametrize(
+    "pauli_op,",
+    [
+        fp.PauliOp,
+    ],
+    ids=resolve_parameter_repr,
+)
+def test_clone(
+    pauli_strings_with_size: Callable,
+    generate_random_complex: Callable,
+    pauli_op: type[fp.PauliOp],
+) -> None:
+    """Test clone method."""
+    string_sets = [
+        ["I", "X", "Y", "Z"],
+        pauli_strings_with_size(2),
+        pauli_strings_with_size(3),
+        ["XYZXYZXYZ", "ZZZIIIXXX"],
+    ]
+
+    for strings in string_sets:
+        coeffs = generate_random_complex(len(strings))
+        op1 = pauli_op(coeffs, strings)
+        op2 = op1.clone()
+
+        np.testing.assert_array_equal(
+            op1.to_tensor(),
+            op2.to_tensor(),
+        )
+        assert id(op1) != id(op2)
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/fast_pauli/test_pauli_string.py
+++ b/tests/fast_pauli/test_pauli_string.py
@@ -405,6 +405,26 @@ def test_exceptions(pauli_string: type[fp.PauliString] | type[pp.PauliString]) -
         pauli_string("XYZ").apply(np.eye(4))
 
 
+@pytest.mark.parametrize(
+    "pauli_string,",
+    [
+        (fp.PauliString),
+    ],
+    ids=resolve_parameter_repr,
+)
+def test_clone(sample_pauli_strings: list, pauli_string: type[fp.PauliString]) -> None:
+    """Test clone method."""
+    for ps in sample_pauli_strings:
+        pstr1 = pauli_string(ps)
+        pstr2 = pstr1.clone()
+
+        np.testing.assert_array_equal(
+            pstr1.to_tensor(),
+            pstr2.to_tensor(),
+        )
+        assert id(pstr1) != id(pstr2)
+
+
 @pytest.mark.consistency
 def test_sparse_composers(paulis: dict, pauli_strings_with_size: Callable) -> None:
     """Test consistency for sparse pauli composers."""

--- a/tests/fast_pauli/test_summed_pauli_op.py
+++ b/tests/fast_pauli/test_summed_pauli_op.py
@@ -237,3 +237,28 @@ def test_square(
     A_k2 = op2.to_tensor()
 
     np.testing.assert_allclose(A_k2, np.einsum("kab,kbc->kac", A_k, A_k))
+
+
+@pytest.mark.parametrize(
+    "summed_pauli_op", [fp.SummedPauliOp], ids=resolve_parameter_repr
+)
+@pytest.mark.parametrize(
+    "n_operators,n_qubits",
+    [(o, q) for o in [1, 10] for q in [1, 2, 4, 6]],
+)
+def test_clone(
+    summed_pauli_op: type[fp.SummedPauliOp],
+    n_operators: int,
+    n_qubits: int,
+) -> None:
+    """Test clone method."""
+    pauli_strings = fp.helpers.calculate_pauli_strings_max_weight(n_qubits, 2)
+    coeffs_2d = np.random.rand(len(pauli_strings), n_operators).astype(np.complex128)
+    op1 = summed_pauli_op(pauli_strings, coeffs_2d)
+    op2 = op1.clone()
+
+    np.testing.assert_array_equal(
+        op1.to_tensor(),
+        op2.to_tensor(),
+    )
+    assert id(op1) != id(op2)

--- a/tests/fast_pauli/test_summed_pauli_op.py
+++ b/tests/fast_pauli/test_summed_pauli_op.py
@@ -262,3 +262,52 @@ def test_clone(
         op2.to_tensor(),
     )
     assert id(op1) != id(op2)
+
+
+@pytest.mark.parametrize(
+    "summed_pauli_op", [fp.SummedPauliOp], ids=resolve_parameter_repr
+)
+@pytest.mark.parametrize(
+    "n_operators,n_qubits",
+    [(o, q) for o in [1, 10] for q in [1, 2, 4, 6]],
+)
+def test_coeffs_prop(
+    summed_pauli_op: type[fp.SummedPauliOp],
+    n_operators: int,
+    n_qubits: int,
+) -> None:
+    """Test getter and setter for coeffs property of the SummedPauliOp."""
+    pauli_strings = fp.helpers.calculate_pauli_strings_max_weight(n_qubits, 2)
+    orig_coeffs = np.random.rand(len(pauli_strings), n_operators).astype(np.complex128)
+    spo = summed_pauli_op(pauli_strings, orig_coeffs)
+
+    np.testing.assert_allclose(spo.coeffs, orig_coeffs.T)
+    new_coeffs = np.random.rand(n_operators, len(pauli_strings)).astype(np.complex128)
+    spo.coeffs = new_coeffs
+    np.testing.assert_allclose(spo.coeffs, new_coeffs)
+    np.testing.assert_allclose(
+        spo.to_tensor(), summed_pauli_op(pauli_strings, new_coeffs.T.copy()).to_tensor()
+    )
+
+
+@pytest.mark.parametrize(
+    "summed_pauli_op", [fp.SummedPauliOp], ids=resolve_parameter_repr
+)
+@pytest.mark.parametrize(
+    "n_operators,n_qubits",
+    [(o, q) for o in [1, 10] for q in [1, 2, 4, 6]],
+)
+def test_split(
+    summed_pauli_op: type[fp.SummedPauliOp],
+    n_operators: int,
+    n_qubits: int,
+) -> None:
+    """Test split method of the SummedPauliOp."""
+    pauli_strings = fp.helpers.calculate_pauli_strings_max_weight(n_qubits, 2)
+    coeffs_2d = np.random.rand(len(pauli_strings), n_operators).astype(np.complex128)
+    spo = summed_pauli_op(pauli_strings, coeffs_2d)
+
+    components = spo.split()
+    for k, (comp, op_dense) in enumerate(zip(components, spo.to_tensor())):
+        np.testing.assert_allclose(comp.coeffs, spo.coeffs[k])
+        np.testing.assert_allclose(comp.to_tensor(), op_dense)


### PR DESCRIPTION
## General
This PR accomplishes following:
* Introduces `.clone()` method for every nanobind wrapper we have
* Adds properties for `coeffs` and `pauli_strings` of `SummedPauliOp` object
* New method to split `SummedPauliOp` into `PauliOp` components

## Related Issues
* Resolves #81