### PR TITLE
bump versions of fmt and nanobind in cmakelists to allow for build in…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,9 +39,9 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Dependencies
 cpmaddpackage("gh:doctest/doctest@2.4.11")
-cpmaddpackage("gh:fmtlib/fmt#10.2.1")
+cpmaddpackage("gh:fmtlib/fmt#11.1.4")
 cpmaddpackage("gh:kokkos/mdspan#b885a2c60ad42f9e1aaa0d317a38105b950cbed0")
-cpmaddpackage("gh:wjakob/nanobind#v2.0.0")
+cpmaddpackage("gh:wjakob/nanobind#v2.6.1")
 
 #
 # User Options

--- a/fast_pauli/cpp/include/__nb_helpers.hpp
+++ b/fast_pauli/cpp/include/__nb_helpers.hpp
@@ -24,9 +24,9 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <experimental/mdspan>
-#include <iostream>
 #include <numeric>
 #include <ranges>
 


### PR DESCRIPTION
Using llvm 20.1.1 on Mac OS 15. Need to bump versions of fmt and nanobind libraries to avoid new deprecation errors.