### PR TITLE
[Bug] CMake 4.0.0 breaks builds (bc of CPM)

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -7,7 +7,7 @@ runs:
       run: python3 ./.github/compiler_setup.py ${CXX} ${BUILD_OS}
     - name: Install Python dependencies
       shell: bash
-      run: python -m pip install cmake<4 scikit-build-core setuptools_scm build
+      run: python -m pip install "cmake<4.0.0" scikit-build-core setuptools_scm build
     - name: Build
       shell: bash
       run: |

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -7,7 +7,7 @@ runs:
       run: python3 ./.github/compiler_setup.py ${CXX} ${BUILD_OS}
     - name: Install Python dependencies
       shell: bash
-      run: python -m pip install cmake scikit-build-core setuptools_scm build
+      run: python -m pip install cmake<4 scikit-build-core setuptools_scm build
     - name: Build
       shell: bash
       run: |


### PR DESCRIPTION
# Summary

The newest CMake breaks CPM (what we use for package management in CMake). Limiting the version on our CI builds for now.