### PR TITLE
[BUG] Pushing wheels to pypi for mac os build fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,9 @@ jobs:
           - os: macos-14
             compiler: g++-12
             python-version: 3.12
+          - os: macos-15
+            compiler: g++-12
+            python-version: 3.12
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,6 @@ jobs:
           - os: macos-14
             compiler: g++-12
             python-version: 3.12
-          - os: macos-15
-            compiler: g++-12
-            python-version: 3.12
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,6 @@ jobs:
             max: 13.0
           - os: macos-14
             max: 14.0
-          - os: macos-15
-            max: 15.0
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           BUILD_OS: ${{ matrix.os }}
           CXX: ${{ matrix.compiler }}
       - name: Publish source dist release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.10
+        uses: pypa/gh-action-pypi-publish@release/v1.12.4
   wheels_build:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -43,15 +43,17 @@ jobs:
             max: 13.0
           - os: macos-14
             max: 14.0
+          - os: macos-15
+            max: 15.0
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.2
+        uses: pypa/cibuildwheel@v2.23.2
         with:
           config-file: "{package}/pyproject.toml"
         env:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.max }}
       - name: Publish wheel release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.10
+        uses: pypa/gh-action-pypi-publish@release/v1.12.4
         with:
           packages-dir: wheelhouse


### PR DESCRIPTION
# Summary

Since the initial release, we haven't supported binary builds for mac because of a limitation in `gh-action-pypi-publish` that only supported linux. This PR (hopefully) addresses that by bumping the version of the action.

# Error

See the GitHub action logs here:
https://github.com/qognitive/fast-pauli/actions/runs/13973566821/job/39121408306#step:4:13